### PR TITLE
Fix 404 page behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13 as builder
+FROM python:3.13 AS builder
 
 RUN pip3 install mkdocs-mermaid2-plugin mkdocs-table-reader-plugin mkdocs-include-markdown-plugin mkdocs-video
 
@@ -12,7 +12,7 @@ COPY --chown=1001:root . .
 # build the docs
 RUN chmod +x prepare_theme.sh && ./prepare_theme.sh
 RUN mkdocs build
-FROM nginxinc/nginx-unprivileged:1.28-alpine as deploy
+FROM nginxinc/nginx-unprivileged:1.28-alpine AS deploy
 COPY --from=builder $HOME/application/site/ /usr/share/nginx/html/saap/
 COPY default.conf /etc/nginx/conf.d/
 

--- a/default.conf
+++ b/default.conf
@@ -2,9 +2,12 @@ server {
     listen 8080;
     root /usr/share/nginx/html/;
     index index.html;
-    error_page 403 404 /404.html;
-    location = /404.html {
+    error_page 403 404 /saap/404.html;
+    location = /saap/404.html {
         internal;
+    }
+    location / {
+        try_files $uri $uri/ /saap/404.html;
     }
     # redirects issued by nginx will be relative
     absolute_redirect off;     


### PR DESCRIPTION
SAAP docs don't handle any rewrites, for example, this link https://docs.stakater.com/saap/asdf returns 404 but should return the custom 4xx page